### PR TITLE
Prevent 'Couldn't find a Game Manager' errors on start up

### DIFF
--- a/QuickWarp/QuickWarpGUI.cs
+++ b/QuickWarp/QuickWarpGUI.cs
@@ -34,8 +34,8 @@ public class QuickWarpGUI : MonoBehaviour
     }
 
     public void OnGUI()
-    {
-        if (GameManager.instance?.IsNonGameplayScene() == true) return;
+    { 
+        if (GameManager.SilentInstance?.IsNonGameplayScene() == true) return;
         if (!Enabled) return;
 
         GUILayout.BeginArea(new Rect(550, 25, 520, 800));


### PR DESCRIPTION
Calling `GameManager.instance` logs an error if the GameManager doesn't exist yet, and the number of these errors from QuickWarp noticeably slows down the start up sequence and fills up the console. Using `GameManager.SilentInstance` instead prevents the error logging.